### PR TITLE
:alien: migrate for tauri 2.2.0 use `show_menu_on_left_click` instead…

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -331,7 +331,7 @@ pub fn run() {
                         m => println!("{}", m),
                     };
                 })
-                .menu_on_left_click(true)
+                .show_menu_on_left_click(true)
                 .build(app)?;
             Ok(())
         })


### PR DESCRIPTION
… of `menu_on_left_click`