### PR TITLE
:wrench: Group Tauri-related deps in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,11 @@ updates:
     directory: "/src-tauri"
     schedule:
       interval: "weekly"
+    groups:
+      tauri:
+        patterns:
+          - "tauri"
+          - "tauri-*"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -22,3 +27,6 @@ updates:
         patterns:
           - "react"
           - "react-dom"
+      tauri:
+        patterns:
+          - "@tauri-apps/*"


### PR DESCRIPTION
Group @tauri-apps/* (npm) and tauri/tauri-* (cargo) so that updates are bundled per ecosystem. This avoids npm/cargo version mismatches that fail Tauri's CLI integrity check, which currently breaks every single-package Tauri plugin bump PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved dependency management automation configuration to better organize and group Tauri-related package updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->