### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test-tauri:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/Portable-Network-Archive/pna-gui/security/code-scanning/1](https://github.com/Portable-Network-Archive/pna-gui/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/test.yml` to enforce least-privilege `GITHUB_TOKEN` access.  
Best single fix without changing behavior is to set workflow-level permissions to the minimal baseline:

- `contents: read`

This satisfies CodeQL’s requirement and documents expected token scope.  
Edit location: near the top of the workflow, after `on:` (or after triggers block) and before `jobs:`.

No imports, methods, or extra definitions are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated testing workflow permissions to allow read-only access to repository contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->