### PR TITLE
Bump TypeScript from 5.9.3 to 6.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "eslint-config-next": "16.2.9",
         "jsdom": "^26.1.0",
         "prettier": "^3.8.3",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.10"
       }
     },
@@ -16438,9 +16438,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "eslint-config-next": "16.2.9",
     "jsdom": "^26.1.0",
     "prettier": "^3.8.3",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.10"
   },
   "overrides": {


### PR DESCRIPTION
## Summary

- Update the direct TypeScript development dependency from `^5.9.3` to `^6.0.3`.
- Update the lockfile to resolve TypeScript 6.0.3.
- Keep this change scoped to TypeScript; no TypeScript 7 upgrade or unrelated dependency updates are included.

## Intent

This PR deliberately stays on the TypeScript 6 major line. TypeScript 6.0.3 is the latest stable 6.x release available from npm at the time of this update. The existing `eslint-config-next@16.2.9` dependency still brings `typescript-eslint@8.57.2`, whose peer range is `>=4.8.4 <6.0.0`; that compatibility work is intentionally left out of this isolated dependency PR.

## Validation

- `node -p "require('./node_modules/typescript/package.json').version"` → 6.0.3
- `npm run build` → passed
- `npm ls typescript` → reports the existing `typescript-eslint <6` peer incompatibility from `eslint-config-next`
- `npm run lint` → fails in the existing ESLint 10 / `eslint-plugin-react` compatibility path (`contextOrFilename.getFilename is not a function`)
- `git diff --check` → passed
