### PR TITLE
Override js-yaml to 4.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12166,9 +12166,9 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,9 @@
     "vitest": "^4.1.10"
   },
   "overrides": {
+    "mocha": {
+      "js-yaml": "4.3.1"
+    },
     "@wdio/tauri-service": {
       "@wdio/native-utils": "2.5.0"
     }


### PR DESCRIPTION
## Summary
- Pin Mocha’s transitive `js-yaml` dependency to 4.3.1.
- Keep the change limited to the npm manifest override and matching lockfile entry.

## Security alert addressed
- Dependabot #174: CVE-2026-59870 quadratic CPU consumption in `js-yaml` `!!omap` resolution.

## Validation
- The lockfile now resolves `js-yaml` to 4.3.1, the first patched release.
- `git diff --check` passed.
- Full repository CI will verify compatibility.
