### PR TITLE
Override serialize-javascript to 7.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14824,9 +14824,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,9 @@
     "vitest": "^4.1.10"
   },
   "overrides": {
+    "mocha": {
+      "serialize-javascript": "7.0.5"
+    },
     "@wdio/tauri-service": {
       "@wdio/native-utils": "2.5.0"
     }


### PR DESCRIPTION
## Summary
- Pin Mocha’s transitive `serialize-javascript` dependency to 7.0.5.
- Keep the change limited to the npm manifest override and matching lockfile entry.

## Security alerts addressed
- Dependabot #138 and #139: vulnerable `serialize-javascript` versions allowing code-generation abuse and CPU exhaustion.

## Validation
- The lockfile now resolves `serialize-javascript` to 7.0.5, the first release covering both alerts.
- `git diff --check` passed.
- Full repository CI will verify compatibility.
